### PR TITLE
typo fix: table2 instead of tables2

### DIFF
--- a/getting-started/ide-quick-tour/4.-common-customizations-and-expanding-your-app/4.3-displaying-data-in-tables-page-builder-and-element-config.md
+++ b/getting-started/ide-quick-tour/4.-common-customizations-and-expanding-your-app/4.3-displaying-data-in-tables-page-builder-and-element-config.md
@@ -11,7 +11,7 @@ BetterForms provides powerful options for displaying tabular data, from simple l
 * Good for data input scenarios
 * Limited sorting and filtering
 
-### 2. **Data Tables (`tables2`)**
+### 2. **Data Tables (`table2`)**
 
 * Advanced data display with sorting, filtering, pagination
 * Read-only data presentation
@@ -154,7 +154,7 @@ Your page's data model should include an array for the list data:
 }
 ```
 
-## Data Tables (`tables2`) Implementation
+## Data Tables (`table2`) Implementation
 
 ### Where to Add Data Tables in the IDE
 
@@ -167,7 +167,7 @@ Your page's data model should include an array for the list data:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Customer List",
   "model": "customers",
   "styleClasses": "col-md-12",
@@ -210,7 +210,7 @@ Your page's data model should include an array of objects:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Order Management",
   "model": "orders",
   "styleClasses": "col-md-12",
@@ -251,7 +251,7 @@ Your page's data model should include an array of objects:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Customer List",
   "model": "customers",
   "styleClasses": "col-md-12",
@@ -271,7 +271,7 @@ Your page's data model should include an array of objects:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Customer List",
   "model": "customers",
   "styleClasses": "col-md-12",
@@ -300,7 +300,7 @@ let customerName = customer.firstName + ' ' + customer.lastName;
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Product Catalog",
   "model": "products",
   "columns": ["name", "price", "inventory", "status", "actions"],
@@ -331,7 +331,7 @@ Display additional details when a row is expanded:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Order List",
   "model": "orders",
   "columns": ["orderNumber", "customer", "total", "status"],
@@ -369,7 +369,7 @@ End If
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "label": "Customer List",
   "model": "customers",
   "columns": ["firstName", "lastName", "email", "actions"],
@@ -388,7 +388,7 @@ End If
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "model": "products",
   "columns": ["name", "category", "price"],
   "options": {
@@ -408,7 +408,7 @@ For numeric sorting of text fields:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "model": "products",
   "columns": ["name", "price", "date"],
   "options": {
@@ -439,7 +439,7 @@ For numeric sorting of text fields:
 
 ```json
 {
-  "type": "tables2",
+  "type": "table2",
   "model": "largeDataset",
   "columns": ["id", "name", "status"],
   "options": {
@@ -461,7 +461,7 @@ For numeric sorting of text fields:
 ### 1. **Choose the Right Component**
 
 * Use `listrows` for data entry
-* Use `tables2` for data display
+* Use `table2` for data display
 * Consider user workflow needs
 
 ### 2. **Optimize User Experience**


### PR DESCRIPTION
There is an important and consequential typo on the page describing "listrows" and "table2" elements: everywhere that the code should say "table2", it wrongly says "tables2" (an extra "s"). That, obviously, means that using the examples results in a table that does not work. 